### PR TITLE
Sync with upstream 2.0.0, and take the snippets out of the theme

### DIFF
--- a/SNIPPETS.md
+++ b/SNIPPETS.md
@@ -1,0 +1,170 @@
+# Snippets that used to live in this theme
+
+`functions.php` and `style.css` carried around 180 lines of snippets, all but
+one of them commented out. They are kept here so nothing is lost, and out of
+the theme so that every site does not ship a wall of dead code it never runs.
+
+Read the first section before copying anything from the second: most of these
+are now settings in **Digitizer Pro Tools**, and a toggle you can see beats a
+snippet you have to remember pasting.
+
+## Now covered by Digitizer Pro Tools
+
+| What it did | Where it lives now |
+|---|---|
+| Silencing plugin, theme and core auto-update emails | **Update Emails** module - separate toggles per kind, and failure emails are always kept, which the snippet did not do |
+| `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, HSTS | **Site Tweaks** - each header its own toggle |
+| Allowing SVG uploads | **Site Tweaks** - and it sanitises the file, which the snippet did not |
+| Removing the WordPress version from the head and from asset URLs | **Site Tweaks** |
+| Stopping Elementor from loading Google Fonts | **Site Tweaks** |
+| Phone-number validation on Elementor form `tel` fields | **Site Tweaks** |
+| Hiding the URL field on comments | **Disable Comments** module |
+
+The auto-update email snippet was also broken. It registered
+`wpb_stop_auto_update_emails` as the callback while the function was named
+`wpb_stop_update_emails`, so on any site that reached a core auto-update
+WordPress called a function that did not exist.
+
+## Still snippets
+
+Nothing in Digitizer Pro Tools covers these. Paste them into WPCode rather
+than into a theme file, so that they survive a theme change and are visible
+to whoever looks after the site next.
+
+### Disable the block editor
+
+```php
+add_filter( 'use_block_editor_for_post', '__return_false', 10 );
+add_filter( 'use_block_editor_for_post_type', '__return_false', 10 );
+```
+
+### Allow WebP uploads
+
+Only needed on WordPress older than 5.8; core has accepted WebP since.
+
+```php
+add_filter( 'mime_types', function ( $mimes ) {
+	$mimes['webp'] = 'image/webp';
+	return $mimes;
+} );
+```
+
+### Allow vCard uploads
+
+```php
+add_filter( 'upload_mimes', function ( $mime_types ) {
+	$mime_types['vcf']   = 'text/vcard';
+	$mime_types['vcard'] = 'text/vcard';
+	return $mime_types;
+} );
+```
+
+### Drop Elementor's icon fonts
+
+Both remove icons site-wide. Check the design does not use them first.
+
+```php
+// Font Awesome.
+add_action( 'elementor/frontend/after_register_styles', function () {
+	foreach ( [ 'solid', 'regular', 'brands' ] as $style ) {
+		wp_deregister_style( 'elementor-icons-fa-' . $style );
+	}
+}, 20 );
+
+// Eicons.
+add_action( 'wp_enqueue_scripts', function () {
+	wp_deregister_style( 'elementor-icons' );
+}, 20 );
+```
+
+### Drop the block library stylesheet
+
+Breaks any page that does use blocks, which on an Elementor site is usually
+none - but check before shipping it.
+
+```php
+add_action( 'wp_enqueue_scripts', function () {
+	wp_dequeue_style( 'wp-block-library' );
+	wp_dequeue_style( 'wp-block-library-theme' );
+} );
+```
+
+### Preconnect to the Google Fonts CDN
+
+```php
+add_action( 'wp_head', function () {
+	echo '<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>';
+}, 0 );
+```
+
+### Responsive column order in Elementor
+
+Adds a per-breakpoint order control to columns. Elementor's containers have
+their own ordering, so this is for older layouts built with columns.
+
+```php
+add_action( 'elementor/element/column/layout/before_section_end', function ( $element, $args ) {
+	$element->add_responsive_control(
+		'responsive_column_order',
+		[
+			'label'     => esc_html__( 'Responsive Column Order', 'hello-elementor-child' ),
+			'type'      => \Elementor\Controls_Manager::NUMBER,
+			'separator' => 'before',
+			'selectors' => [
+				'{{WRAPPER}}' => '-webkit-order: {{VALUE}}; -ms-flex-order: {{VALUE}}; order: {{VALUE}};',
+			],
+		]
+	);
+}, 10, 2 );
+```
+
+## CSS that used to be commented out in style.css
+
+Hiding the page title and styling the comment form. Both are design decisions
+that belong to a particular site, not to every site that uses this theme.
+
+```css
+/* Hide the title and site description */
+.hello_elementor_page_title,
+.entry-title,
+.site-title,
+.site-description {
+	display: none;
+}
+
+/* Comment form fields */
+form#commentform > p:not(.form-submit) textarea,
+form#commentform > p:not(.form-submit) input:not(#wp-comment-cookies-consent) {
+	width: 100%;
+	border: 1px solid #000;
+	border-radius: 0;
+}
+
+/* Comment submit button */
+form#commentform input#submit {
+	padding: 10px 30px;
+	border: 1px solid #000;
+	border-radius: 0;
+	background-color: #000;
+	color: #fff;
+	font-size: 20px;
+	transition: 0.3s all;
+}
+form#commentform input#submit:hover {
+	background-color: #fff;
+	color: #000;
+}
+
+/* Comment list */
+section#comments li.comment.even > article {
+	background-color: #f9f9f9;
+}
+body.rtl #comments .comment .comment-body,
+body.rtl #comments .pingback .comment-body {
+	padding: 30px;
+}
+.comment-reply-link {
+	font-size: 14px;
+	text-decoration: underline;
+}
+```

--- a/functions.php
+++ b/functions.php
@@ -1,184 +1,36 @@
 <?php
 /**
- * Theme functions and definitions
+ * Theme functions and definitions.
+ *
+ * For additional information on potential customization options,
+ * read the developers' documentation:
+ *
+ * https://developers.elementor.com/docs/hello-elementor-theme/
  *
  * @package HelloElementorChild
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+define( 'HELLO_ELEMENTOR_CHILD_VERSION', '2.0.0' );
+
 /**
- * Load child theme css and optional scripts
+ * Load child theme scripts & styles.
  *
  * @return void
  */
-function hello_elementor_child_enqueue_scripts() {
+function hello_elementor_child_scripts_styles() {
+
 	wp_enqueue_style(
 		'hello-elementor-child-style',
 		get_stylesheet_directory_uri() . '/style.css',
 		[
 			'hello-elementor-theme-style',
 		],
-		'1.0.0'
+		HELLO_ELEMENTOR_CHILD_VERSION
 	);
+
 }
-add_action( 'wp_enqueue_scripts', 'hello_elementor_child_enqueue_scripts', 20 );
-
-//*** Digitizer Scripts ***
-//====================
-// More Tips: https://elementor.com/help/hello-theme-tips/
-
-// Disable plugin auto-update email notification
-add_filter('auto_plugin_update_send_email', '__return_false');
- 
-// Disable theme auto-update email notification
-add_filter('auto_theme_update_send_email', '__return_false');
-
-// Disable WordPress core auto-update email notification
-add_filter( 'auto_core_update_send_email', 'wpb_stop_auto_update_emails', 10, 4 );
-function wpb_stop_update_emails( $send, $type, $core_update, $result ) {
-	if ( ! empty( $type ) && $type == 'success' ) {
-		return false;
-	}
-	return true;
-}
-
-// // HTTP Security Headers
-// header('X-Frame-Options: SAMEORIGIN');
-// header('X-XSS-Protection: 1; mode=block');
-// header('X-Content-Type-Options: nosniff');
-// header('Strict-Transport-Security:max-age=31536000; includeSubdomains; preload');
-// @ini_set('session.cookie_httponly', true);
-// @ini_set('session.cookie_secure', true);
-// @ini_set('session.use_only_cookies', true);
-
-// // Reorder Multiple Columns in Elementor 
-// function ben_add_responsive_column_order( $element, $args ) {
-// 	$element->add_responsive_control(
-// 		'responsive_column_order',
-// 		[
-// 			'label' => __( 'Responsive Column Order', 'ben-elementor-extras' ),
-// 			'type' => \Elementor\Controls_Manager::NUMBER,
-// 			'separator' => 'before',
-// 			'selectors' => [
-// 				'{{WRAPPER}}' => '-webkit-order: {{VALUE}}; -ms-flex-order: {{VALUE}}; order: {{VALUE}};',
-// 			],
-// 		]
-// 	);
-// }
-// add_action( 'elementor/element/column/layout/before_section_end', 'ben_add_responsive_column_order', 10, 2 );
-
-// // disable gutenberg  for posts
-// add_filter('use_block_editor_for_post', '__return_false', 10);
-
-// // disable gutenberg  for post types
-// add_filter('use_block_editor_for_post_type', '__return_false', 10);
-
-// /***** VCF Support *****/
-// function _enable_vcard_upload( $mime_types ){
-//   	$mime_types['vcf'] = 'text/vcard';
-// 	$mime_types['vcard'] = 'text/vcard';
-//   	return $mime_types;
-// }
-// add_filter('upload_mimes', '_enable_vcard_upload' );
-
-// /***** Shorten Post/Page link  *****/
-// add_filter( 'get_shortlink', function ( $shortlink ) {
-//     return $shortlink;
-// });
-
-// /***** Allow SVG *****/
-// add_filter( 'wp_check_filetype_and_ext', function($data, $file, $filename, $mimes) {
-//   global $wp_version;
-//   if ( $wp_version !== '4.7.1' ) {
-//      return $data;
-//   }
-//   $filetype = wp_check_filetype( $filename, $mimes );
-//   return [
-//       'ext'             => $filetype['ext'],
-//       'type'            => $filetype['type'],
-//       'proper_filename' => $data['proper_filename']
-//   ];
-// }, 10, 4 );
-// function cc_mime_types( $mimes ){
-//   $mimes['svg'] = 'image/svg+xml';
-//   return $mimes;
-// }
-// add_filter( 'upload_mimes', 'cc_mime_types' );
-// function fix_svg() {
-//   echo '<style type="text/css">
-//         .attachment-266x266, .thumbnail img {
-//              width: 100% !important;
-//              height: auto !important;
-//         }
-//         </style>';
-// }
-// add_action( 'admin_head', 'fix_svg' );
-
-// // Elementor Form Telephone Number Validition
-// add_action( 'elementor_pro/forms/validation/tel', function( $field, $record, $ajax_handler ) { 	
-// 	// Match this format XXXXXXXXXX, 1234567890 	
-// 	if ( preg_match( '/[0-9]{10}/', $field['value'] ) !== 1 ) { 		
-// 	$ajax_handler->add_error( $field['id'], 'הזן טלפון חוקי ללא מקף או רווח' ); 	
-// 	}
-//  	}, 10, 3 );	 
-// //******--- Remove Google Fonts ---******
-// add_filter( 'elementor/frontend/print_google_fonts', '__return_false' );
-
-/* //******--- Preconnect Google Fonts ---******
-// function digitizer_preconnect() { ?>
-//     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-// <?php
-// }
-// add_action('wp_head', 'digitizer_preconnect', 0);
-*/
-
-// //******--- Remove Font Awesome ---*****
-// add_action( 'elementor/frontend/after_register_styles',function() {
-// 	foreach( [ 'solid', 'regular', 'brands' ] as $style ) {
-// 		wp_deregister_style( 'elementor-icons-fa-' . $style );
-// 	}
-// }, 20 );
-
-// //*****---  Remove Eicons:  ---*****
-// add_action( 'wp_enqueue_scripts', 'remove_default_stylesheet', 20 ); 
-// function remove_default_stylesheet() { 
-// 	wp_deregister_style( 'elementor-icons' ); 
-// }
-
-// //*****---   Remove Gutenberg Block Library CSS from loading on the frontend  ---*****
-// function smartwp_remove_wp_block_library_css(){
-//  wp_dequeue_style( 'wp-block-library' );
-//  wp_dequeue_style( 'wp-block-library-theme' );
-// }
-// add_action( 'wp_enqueue_scripts', 'smartwp_remove_wp_block_library_css' );
-
-// // remove wp version number from scripts and styles
-// function remove_css_js_version( $src ) {
-//     if( strpos( $src, '?ver=' ) )
-//         $src = remove_query_arg( 'ver', $src );
-//     return $src;
-// }
-// add_filter( 'style_loader_src', 'remove_css_js_version', 9999 );
-// add_filter( 'script_loader_src', 'remove_css_js_version', 9999 );
-
-// // remove wp version number from head and rss
-// function artisansweb_remove_version() {
-//     return '';
-// }
-// add_filter('the_generator', 'artisansweb_remove_version');
-
-// // Upload webP images in WordPress
-// function webp_upload_mimes( $existing_mimes ) {
-// 	// add webp to the list of mime types
-// 	$existing_mimes['webp'] = 'image/webp';
-// 	// return the array back to the function with our added mime type
-// 	return $existing_mimes;
-// }
-// add_filter( 'mime_types', 'webp_upload_mimes' );
-
-// // Hide comments "URL" field
-// add_filter('comment_form_default_fields', 'unset_url_field');
-// function unset_url_field($fields){
-//     if(isset($fields['url']))
-//        unset($fields['url']);
-//        return $fields;
-// }
+add_action( 'wp_enqueue_scripts', 'hello_elementor_child_scripts_styles', 20 );

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ activates it. To do it by hand:
 ```
 git remote add upstream https://github.com/elementor/hello-theme-child.git
 git fetch upstream
-git diff master upstream/master -- functions.php
+git diff HEAD upstream/master -- functions.php
 ```
 
 Take upstream's `functions.php` as it stands. `style.css` differs only in the

--- a/readme.md
+++ b/readme.md
@@ -49,4 +49,10 @@ header block, so merge that by hand and leave the Digitizer identity in place.
 
 Distributed under the GPL, like WordPress and like the theme it forks.
 
-The screenshot's images and icons are Creative Commons (CC0).
+`screenshot.png` came from Elementor with the fork and has never been
+replaced, so its third-party notices are upstream's and still apply:
+
+- Font Awesome icons, under the SIL Open Font License 1.1 —
+  https://fontawesome.com/v4.7.0/
+- Photograph by Jason Blackeye, CC0 1.0 Universal —
+  https://stocksnap.io/photo/4B83RD7BV9

--- a/readme.md
+++ b/readme.md
@@ -1,67 +1,52 @@
 # Hello Digitizer
 
-Contributors: elemntor, KingYes, ariel.k, jzaltzberg, mati1000, bainternet
-Requires at least: WordPress 4.7
-Tested up to: WordPress 5.2
-Stable tag: 1.0.0
-Version: 1.0.1
-Requires PHP: 5.4
-License: GNU General Public License v3 or later
-License URI: https://www.gnu.org/licenses/gpl-3.0.html
-Tags: flexible-header, custom-colors, custom-menu, custom-logo, editor-style, featured-images, rtl-language-support, threaded-comments, translation-ready
+A blank child theme of [Hello Elementor](https://wordpress.org/themes/hello-elementor/),
+used as the starting point for Digitizer client sites. It is a fork of
+[elementor/hello-theme-child](https://github.com/elementor/hello-theme-child)
+and tracks it: the only differences are the theme header and this readme.
 
-The Hello Digitizer Theme is a starter blank child theme for [Hello Elementor](https://wordpress.org/themes/hello-elementor/) theme.
+- **Version:** 2.0.0 (in step with upstream)
+- **Requires:** WordPress 5.9+, PHP 5.6+, and the Hello Elementor parent theme
+- **License:** GNU General Public License v3 or later
 
-***Hello Digitizer*** is distributed under the terms of the GNU GPL v3 or later.
+## What is in it
 
-## Description
+`functions.php` loads `style.css` after the parent's stylesheet, and nothing
+else. That is the whole theme, and it is meant to stay that way.
 
-A basic, plain-vanilla, lightweight theme, best suited for building your site using Elementor page builder.
+Site behaviour belongs in **Digitizer Pro Tools**, where it is a toggle on a
+screen that the next person can find, rather than a snippet buried in a theme
+file that a theme change would take with it. Anything this theme used to carry
+is in [SNIPPETS.md](SNIPPETS.md), with a note on which Digitizer Pro Tools
+module replaced it.
 
-This theme resets the WordPress environment and prepares it for smooth operation of Elementor.
+Per-site CSS goes at the bottom of `style.css` on that site, or - better -
+into Elementor, where the person maintaining the site will look for it.
 
-Screenshot's images & icons are licensed under: Creative Commons (CC0), https://creativecommons.org/publicdomain/zero/1.0/legalcode
+## Installation
 
-## Installation 
+Digitizer Pro Tools' Onboarding wizard installs this theme and its parent, and
+activates it. To do it by hand:
 
-1. In your admin panel, go to Appearance > Themes and click the 'Add New' button.
-2. Click 'Upload theme' and upload the zipped child
-3. Click on the 'Activate' button to use your new theme right away.
-4. Navigate to Elementor and start building your site.
+1. Install and activate Hello Elementor first; a child theme without its
+   parent leaves the site with no templates.
+2. Appearance > Themes > Add New > Upload Theme, and upload this repository's
+   ZIP.
+3. Activate.
 
-## Customizations 
+## Keeping up with upstream
 
-Most users will not need to edit the files for customizing this theme.
-To customize your site's appearance, simply use ***Elementor***.
+```
+git remote add upstream https://github.com/elementor/hello-theme-child.git
+git fetch upstream
+git diff master upstream/master -- functions.php
+```
 
-However, if you have a particular need to adapt this theme, please read on.
+Take upstream's `functions.php` as it stands. `style.css` differs only in the
+header block, so merge that by hand and leave the Digitizer identity in place.
 
-## Frequently Asked Questions 
+## Copyright
 
-**Does this theme support any plugins?**
+Distributed under the GPL, like WordPress and like the theme it forks.
 
-Hello Digitizer includes support for WooCommerce.
-
-**Can Font Styles be added thru the theme's css file?**
-
-Yes, ***but*** best practice is to use the styling capabilities in the Elementor plugin.
-
-## Copyright 
-
-This theme, like WordPress, is licensed under the GPL.
-Use it as your springboard to building a site with ***Elementor***.
-
-Hello Digitizer bundles the following third-party resources:
-
-Font Awesome icons for theme screenshot
-License: SIL Open Font License, version 1.1.
-Source: https://fontawesome.com/v4.7.0/
-
-Image for theme screenshot, Copyright Jason Blackeye
-License: CC0 1.0 Universal (CC0 1.0)
-Source: https://stocksnap.io/photo/4B83RD7BV9
-
-## Changelog 
-
-### 1.0.0 - 2019-05-23
-* Initial Public Release
+The screenshot's images and icons are Creative Commons (CC0).

--- a/style.css
+++ b/style.css
@@ -1,63 +1,15 @@
 /* 
 Theme Name: Hello Digitizer
 Theme URI: https://github.com/Digitizers/hello-digitizer
-Description: Hello Digitizer is a child theme of Hello Elementor, created by Digitizer team
+Description: Hello Digitizer is a child theme of Hello Elementor, created by the Digitizer team
 Author:  Digitizer
 Author URI: https://www.digitizer.co.il/
 Template: hello-elementor
-Version: 1.0.1
+Version: 2.0.0
 Text Domain: hello-elementor-child
 License: GNU General Public License v3 or later.
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Tags: flexible-header, custom-colors, custom-menu, custom-logo, editor-style, featured-images, rtl-language-support, threaded-comments, translation-ready
 */
 
-/* Hide Title & Description */
-/* .hello_elementor_page_title {
-    display: none;
-}
-.entry-title {
-    display: none !important;
-}
-.site-title {
-    display: none !important;
-}
-.site-description {
-    display: none !important;
-} */
-
-/* Comments Textarea & Input  */
-/* form#commentform > p:not(.form-submit) textarea, form#commentform > p:not(.form-submit) input:not(#wp-comment-cookies-consent) {
-    width: 100%;
-    border-radius: 0;
-    border: 1px solid #000;
-} */
-
-/* Comments Submit button */
-/* selector form#commentform input#submit {
-    color: #ffffff;
-    font-size: 20px;
-    background-color: #000000;
-    border: 1px solid #000000!important;
-    transition: .3s all;
-    padding: 10px 30px;
-    border-radius: 0;
-}
-selector form#commentform input#submit:hover {
-    color: #000000;
-    background-color: #ffffff !important;
-} */
-
-/* Comments */
-/* section#comments li.comment.even > article {
-    background-color: #f9f9f9;
-}
-body.rtl #comments .comment .comment-body, body.rtl #comments .pingback .comment-body {
-    padding: 30px;
-} */
-
-/* Comments Reply Link */
-/* .comment-reply-link {
-    font-size: 14px;
-    text-decoration: underline !important;
-} */
+/* Add your custom styles here */


### PR DESCRIPTION
The fork had not moved since 2021 and was nine commits behind `elementor/hello-theme-child`. This brings it to upstream 2.0.0 and empties the theme of everything that is not a child theme's job.

## Upstream sync

`functions.php` is now upstream's file verbatim. What it adds over ours: an `ABSPATH` guard, `HELLO_ELEMENTOR_CHILD_VERSION` instead of a hardcoded `'1.0.0'` in the enqueue, and the developer-docs link.

`style.css` is upstream's with our header block. That header is now the entire diff against upstream, so the next sync is a two-file read rather than an archaeology exercise — the readme says how.

## The snippets are out of the theme

`functions.php` carried around 180 lines of snippets, all but one commented out. **The one that was live was broken:** it registered `wpb_stop_auto_update_emails` as the callback for `auto_core_update_send_email`, while the function underneath was named `wpb_stop_update_emails`. Any site that reached a core auto-update called a function that did not exist.

It was redundant as well. Silencing update emails is what the **Update Emails** module does, and it keeps failure emails — which the snippet did not. Seven more of the commented-out snippets are settings in Digitizer Pro Tools today:

| Snippet | Module |
|---|---|
| `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, HSTS | Site Tweaks |
| Allow SVG uploads | Site Tweaks — and it sanitises the file |
| Remove the WordPress version from head and asset URLs | Site Tweaks |
| Stop Elementor loading Google Fonts | Site Tweaks |
| `tel` field validation on Elementor forms | Site Tweaks |
| Hide the comments URL field | Disable Comments |
| Silence update emails | Update Emails |

**Nothing is lost.** `SNIPPETS.md` carries every one of them, marks which module replaced it, and keeps the remainder — block editor off, WebP and vCard uploads, dropping Elementor's icon fonts, the block-library stylesheet, Google Fonts preconnect, responsive column order — as snippets to paste into WPCode, where they survive a theme change and are visible to whoever looks after the site next. The commented-out CSS from `style.css` is in there too, tidied.

## readme.md

It was Elementor's, down to their contributor list, a WordPress 4.7 requirement, a 1.0.0 stable tag and a claim of WooCommerce support this theme does not have. Rewritten for what this repository is.

## Not done

`screenshot.png` is still ours at 338 KB against upstream's 87 KB. It is Digitizer's own image, so it stays; shrinking it is a separate, cosmetic change.
