### PR TITLE
Settle the snippets: three moved into the plugin, five deleted

### DIFF
--- a/SNIPPETS.md
+++ b/SNIPPETS.md
@@ -4,9 +4,10 @@
 one of them commented out. They are kept here so nothing is lost, and out of
 the theme so that every site does not ship a wall of dead code it never runs.
 
-Read the first section before copying anything from the second: most of these
-are now settings in **Digitizer Pro Tools**, and a toggle you can see beats a
-snippet you have to remember pasting.
+Every one of them has since been settled: either it became a setting in
+**Digitizer Pro Tools**, where a toggle you can see beats a snippet you have to
+remember pasting, or it was deleted for a reason worth writing down. This file
+is now a record of where each went, not a place to copy from.
 
 ## Now covered by Digitizer Pro Tools
 
@@ -19,152 +20,33 @@ snippet you have to remember pasting.
 | Stopping Elementor from loading Google Fonts | **Site Tweaks** |
 | Phone-number validation on Elementor form `tel` fields | **Site Tweaks** |
 | Hiding the URL field on comments | **Disable Comments** module |
+| Dropping Elementor's Font Awesome and eicons stylesheets | **Site Tweaks** - one toggle for all four stylesheets, where the snippet was two separate hooks to remember |
+| Dropping the block library stylesheet | **Site Tweaks** - front end only, so the editor still works |
+| Disabling the block editor | **Site Tweaks** |
 
 The auto-update email snippet was also broken. It registered
 `wpb_stop_auto_update_emails` as the callback while the function was named
 `wpb_stop_update_emails`, so on any site that reached a core auto-update
 WordPress called a function that did not exist.
 
-## Still snippets
+## Deleted, and why
 
-Nothing in Digitizer Pro Tools covers these. Paste them into WPCode rather
-than into a theme file, so that they survive a theme change and are visible
-to whoever looks after the site next.
+The rest of what this file held has been removed rather than carried. Each of
+them was either already done by WordPress, or a decision that belongs to one
+site and not to a theme:
 
-### Disable the block editor
+- **Allowing WebP uploads.** Core has accepted WebP since WordPress 5.8. The
+  snippet was already dead when it was written down.
+- **Allowing vCard uploads.** One client, once. Widening what may be uploaded
+  across every site is a poor trade for a case that has not come back.
+- **Preconnecting to the Google Fonts CDN.** Only worth anything if Google
+  Fonts are loading, and Site Tweaks has a toggle that stops Elementor loading
+  them. Two settings arguing with each other.
+- **Responsive column order in Elementor.** Columns are the old layout
+  primitive; containers order themselves. It applies only to layouts nobody
+  builds now.
+- **The commented-out CSS** - hiding the page title, styling the comment form.
+  Design decisions for a particular site, which is where they should live.
 
-```php
-add_filter( 'use_block_editor_for_post', '__return_false', 10 );
-add_filter( 'use_block_editor_for_post_type', '__return_false', 10 );
-```
-
-### Allow WebP uploads
-
-Only needed on WordPress older than 5.8; core has accepted WebP since.
-
-```php
-add_filter( 'mime_types', function ( $mimes ) {
-	$mimes['webp'] = 'image/webp';
-	return $mimes;
-} );
-```
-
-### Allow vCard uploads
-
-```php
-add_filter( 'upload_mimes', function ( $mime_types ) {
-	$mime_types['vcf']   = 'text/vcard';
-	$mime_types['vcard'] = 'text/vcard';
-	return $mime_types;
-} );
-```
-
-### Drop Elementor's icon fonts
-
-Both remove icons site-wide. Check the design does not use them first.
-
-```php
-// Font Awesome.
-add_action( 'elementor/frontend/after_register_styles', function () {
-	foreach ( [ 'solid', 'regular', 'brands' ] as $style ) {
-		wp_deregister_style( 'elementor-icons-fa-' . $style );
-	}
-}, 20 );
-
-// Eicons.
-add_action( 'wp_enqueue_scripts', function () {
-	wp_deregister_style( 'elementor-icons' );
-}, 20 );
-```
-
-### Drop the block library stylesheet
-
-Breaks any page that does use blocks, which on an Elementor site is usually
-none - but check before shipping it.
-
-```php
-add_action( 'wp_enqueue_scripts', function () {
-	wp_dequeue_style( 'wp-block-library' );
-	wp_dequeue_style( 'wp-block-library-theme' );
-} );
-```
-
-### Preconnect to the Google Fonts CDN
-
-```php
-add_action( 'wp_head', function () {
-	echo '<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>';
-}, 0 );
-```
-
-### Responsive column order in Elementor
-
-Adds a per-breakpoint order control to columns. Elementor's containers have
-their own ordering, so this is for older layouts built with columns.
-
-```php
-add_action( 'elementor/element/column/layout/before_section_end', function ( $element, $args ) {
-	$element->add_responsive_control(
-		'responsive_column_order',
-		[
-			'label'     => esc_html__( 'Responsive Column Order', 'hello-elementor-child' ),
-			'type'      => \Elementor\Controls_Manager::NUMBER,
-			'separator' => 'before',
-			'selectors' => [
-				'{{WRAPPER}}' => '-webkit-order: {{VALUE}}; -ms-flex-order: {{VALUE}}; order: {{VALUE}};',
-			],
-		]
-	);
-}, 10, 2 );
-```
-
-## CSS that used to be commented out in style.css
-
-Hiding the page title and styling the comment form. Both are design decisions
-that belong to a particular site, not to every site that uses this theme.
-
-```css
-/* Hide the title and site description */
-.hello_elementor_page_title,
-.entry-title,
-.site-title,
-.site-description {
-	display: none;
-}
-
-/* Comment form fields */
-form#commentform > p:not(.form-submit) textarea,
-form#commentform > p:not(.form-submit) input:not(#wp-comment-cookies-consent) {
-	width: 100%;
-	border: 1px solid #000;
-	border-radius: 0;
-}
-
-/* Comment submit button */
-form#commentform input#submit {
-	padding: 10px 30px;
-	border: 1px solid #000;
-	border-radius: 0;
-	background-color: #000;
-	color: #fff;
-	font-size: 20px;
-	transition: 0.3s all;
-}
-form#commentform input#submit:hover {
-	background-color: #fff;
-	color: #000;
-}
-
-/* Comment list */
-section#comments li.comment.even > article {
-	background-color: #f9f9f9;
-}
-body.rtl #comments .comment .comment-body,
-body.rtl #comments .pingback .comment-body {
-	padding: 30px;
-}
-.comment-reply-link {
-	font-size: 14px;
-	text-decoration: underline;
-}
-```
+They are in this repository's history if one of them is ever wanted again:
+`git log --all -p -- SNIPPETS.md`.


### PR DESCRIPTION
`SNIPPETS.md` was written as a holding pen when the theme was emptied in #2. A holding pen with no exit becomes a place things get copied from years later, so this closes it: every snippet in it is now either a setting or a deletion, each with the reason next to it.

## Moved into Digitizer Pro Tools (1.25.0, Site Tweaks)

- **Dropping Elementor's icon fonts** — Font Awesome's three stylesheets and eicons, one toggle instead of two hooks to remember.
- **Dropping the block library stylesheets** — front end only, so the editor still works.
- **Disabling the block editor.**

All three are off by default there. Each breaks something *visible* when it is wrong — an icon that becomes an empty square reads as a broken design rather than as a setting — so the switches carry that warning.

## Deleted

| Snippet | Why |
|---|---|
| WebP uploads | Core has accepted WebP since WordPress 5.8; it was already dead when it was written down |
| vCard uploads | One case, once, in exchange for widening what may be uploaded on every site |
| Google Fonts preconnect | Only worth anything if Google Fonts load, and Site Tweaks has a toggle that stops Elementor loading them — two settings arguing with each other |
| Responsive column order in Elementor | Columns are the old layout primitive; containers order themselves |
| The commented-out CSS | Hiding the page title, styling the comment form — design decisions belonging to one site |

Nothing is lost that git does not hold, and the file says where to look: `git log --all -p -- SNIPPETS.md`.

The file's opening paragraph was also rewritten. It described a document to copy from; it is now a record of where each snippet went.
